### PR TITLE
Dead cell aliveness fix

### DIFF
--- a/frmConway.frm
+++ b/frmConway.frm
@@ -149,7 +149,7 @@ Private Sub timerRun_Timer()
 
             If chkCell(idx).Value = 0 Then
                 ' it's currently dead
-                If liveNeighbours >= 3 Then
+                If liveNeighbours = 3 Then
                     futureState(idx) = True
                 End If
             Else


### PR DESCRIPTION
Dead cells only come alive with exactly 3 neighbours, not >= 3:

> Any dead cell with exactly three live neighbours becomes a live cell, as if by reproduction.